### PR TITLE
Fix session tracking crash on non-US locales

### DIFF
--- a/modules/ProcessFunctions.psm1
+++ b/modules/ProcessFunctions.psm1
@@ -120,7 +120,7 @@ function MonitorGame($DetectedExe) {
 
     # Capture process start time for session history
     $processStartTime = ($null = [System.Diagnostics.Process]::GetProcessesByName($DetectedExe)).StartTime | Sort-Object | Select-Object -First 1
-    $sessionStartTimeUnix = [int](Get-Date ($processStartTime.ToUniversalTime()) -UFormat %s)
+    $sessionStartTimeUnix = (Get-Date ($processStartTime.ToUniversalTime()) -UFormat %s).Split('.').Split(',').Get(0)
 
     if (IsExeEmulator $DetectedExe) {
         $emulatedGameDetails = FindEmulatedGameDetails $DetectedExe


### PR DESCRIPTION
The Unix timestamp conversion in TimeTrackerLoop used [int] cast on the output of -UFormat %s, which fails on systems with comma decimal separators (e.g., Dutch, German, French locales).

Changed to string split approach matching the pattern already used elsewhere in the codebase, splitting on both '.' and ',' to handle any locale.